### PR TITLE
First Setup System

### DIFF
--- a/DiskIndex/Components/DialogFirstSetup.razor
+++ b/DiskIndex/Components/DialogFirstSetup.razor
@@ -1,0 +1,46 @@
+﻿<MudDialog>
+    <TitleContent>
+		<h2>Directory Setup</h2>
+    </TitleContent>
+    <DialogContent>
+        First time using DiskIndex?
+        <br />Its no biggie! Enter the folder path you'd like to use:
+
+        @if(Directory.Exists(TextValue) == true)
+        {
+            <MudTextField @bind-Value="TextValue" Label="Example: D:\Animals\CuteCatsFolder" HelperText="Looks fine! Click the Apply button to proceed."  Variant="Variant.Filled" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.CheckCircle" AdornmentColor="Color.Success" Immediate="true"></MudTextField>
+        }
+        else
+        {
+            <MudTextField @bind-Value="TextValue" Label="Example: D:\Animals\CuteCatsFolder" HelperText="Seems like the directory doesn't exists or its empty, double check it!" Variant="Variant.Filled" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Clear" AdornmentColor="Color.Error" Immediate="true"></MudTextField>
+        }
+
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+
+        @if (Directory.Exists(TextValue) == true)
+        {
+            <MudButton Color="Color.Primary" OnClick="Submit">Apply</MudButton>
+        }
+        else
+        {
+            <MudButton Disabled="true">Apply</MudButton>
+        }
+
+    </DialogActions>
+</MudDialog>
+@code {
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; }
+
+    public string TextValue { get; set; }
+
+    private void Submit()
+    {
+        RootFolderCheck.SetRootFolderPath(TextValue);
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+       
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/DiskIndex/Components/Pages/Home.razor
+++ b/DiskIndex/Components/Pages/Home.razor
@@ -10,6 +10,7 @@
 
 @inject ICatalogService catalogService
 @inject MudBlazor.ISnackbar snackBar
+@inject MudBlazor.IDialogService dialogService
 
 <PageTitle>Home</PageTitle>
 
@@ -75,10 +76,22 @@ Filterable="true">
     private bool syncLoading = false;
     private string firstLine = string.Empty;
 
+    private readonly DialogOptions _backdropClick = new() { BackdropClick = false };
+
 
     private async Task<GridData<FileRecord>> LoadServerData(GridState<FileRecord> state)
     {
         loading = true;
+
+        string rootFolder = RootFolderCheck.GetRootFolderPath();
+
+        if(rootFolder == "" || rootFolder == string.Empty || rootFolder == " ")
+        {
+            var options = _backdropClick;
+            var dialog = await dialogService.ShowAsync<DialogFirstSetup>("Setup", options);
+            var result = await dialog.Result;
+        }
+
         var skip = state.Page * state.PageSize;
         var take = state.PageSize;
 

--- a/DiskIndex/Models/RootFolderCheck.cs
+++ b/DiskIndex/Models/RootFolderCheck.cs
@@ -6,7 +6,7 @@ namespace DiskIndex.Models
     {
         private static Dictionary<string, string> _rootFolder;
 
-        //Unused for now, it will serve as a method to set the root folder to the JSON file for the first setup.
+        // Writes into the rootFolderPath.json, right now only used by the first setup system
         public static void SetRootFolderPath(string path)
         {
             _rootFolder = new Dictionary<string, string>{{ "rootFolderPath", path }};


### PR DESCRIPTION
DiskIndex now checks if the rootFolderPath.json is correctly configured, if its empty it will activate a dialog pop-up to enter the directory.

The system will check if the directory inserted in the dialog exists otherwise it will not apply the changes; if the directory is correct and the User clicks "Apply" the system will automatically write it in the rootFolderPath.json without the need of manually modifying the file.

Its still possible to escape the pop-up with a "Cancel" button.